### PR TITLE
docs(docs/dev): correct cheatcodes.rs's md link path

### DIFF
--- a/docs/dev/cheatcodes.md
+++ b/docs/dev/cheatcodes.md
@@ -113,7 +113,7 @@ The way bindings are generated and extra information can be found in the [`sol!`
 
 We leverage this macro to apply the [`Cheatcode` derive macro](#cheatcode-derive-macro) on the `Vm` interface.
 
-### [`Cheatcode`](../../crates/macros/impl/src/cheatcodes.rs) derive macro
+### [`Cheatcode`](../../crates/macros/src/cheatcodes.rs) derive macro
 
 This is derived once on the `Vm` interface declaration, which recursively applies it to all of the
 interface's items, as well as the `sol!`-generated items, such as the `VmCalls` enum.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
original link's broken
<img width="1630" alt="image" src="https://github.com/AdventureSeeker987/foundry/assets/153156292/1e0ab3b5-0d2a-4496-9882-139695d42e35">

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
replace with correct path

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
